### PR TITLE
方便管理员更改灵根，配合n连使用更佳

### DIFF
--- a/nonebot_plugin_xiuxian/__init__.py
+++ b/nonebot_plugin_xiuxian/__init__.py
@@ -712,6 +712,27 @@ async def _(bot: Bot, event: GroupMessageEvent, args: Message = CommandArg()):
         await give_stone.finish(f"全服通告：赠送所有用户{give_stone_num}灵石,请注意查收！")
 
 
+#GM改灵根
+@command.gmm_command.handle()
+async def _(bot: Bot, event: GuildMessageEvent, args: Message = CommandArg()):
+    give_qq = None  # 艾特的时候存到这里
+    msg = args.extract_plain_text().strip()
+
+    for arg in args:
+        if arg.type == "at":
+            give_qq = arg.data.get("qq", "")
+
+    give_user = sql_message.get_user_message(give_qq)
+    if give_user:
+        sql_message.update_root(give_qq, msg)
+        sql_message.update_power2(give_qq)
+        await gmm_command.finish(
+            "{}道友的修仙境界已变更！".format(give_user.user_name)
+        )
+    else:
+        await gmm_command.finish("对方未踏入修仙界，不可修改！")
+
+
 @command.rob_stone.handle()
 async def _(bot: Bot, event: GroupMessageEvent, args: Message = CommandArg()):
     """抢灵石

--- a/nonebot_plugin_xiuxian/xiuxian2_handle.py
+++ b/nonebot_plugin_xiuxian/xiuxian2_handle.py
@@ -314,6 +314,33 @@ class XiuxianDateManage:
             cur.execute(sql, (price, user_id))
             self.conn.commit()
 
+    def update_root(self, user_id, key):
+        """更新灵根  1为混沌，2为融合，3为超，4为龙，5为天"""
+        cur = self.conn.cursor()
+        print(user_id)
+        print(key)
+
+        if int(key) == 1:
+            sql = f"UPDATE user_xiuxian SET root=?,root_type=? WHERE user_id=?"
+            cur.execute(sql, ("全属性灵根", "混沌灵根", user_id))
+            self.conn.commit()
+        elif int(key) == 2:
+            sql = f"UPDATE user_xiuxian SET root=?,root_type=? WHERE user_id=?"
+            cur.execute(sql, ("融合万物灵根", "融合灵根", user_id))
+            self.conn.commit()
+        elif int(key) == 3:
+            sql = f"UPDATE user_xiuxian SET root=?,root_type=? WHERE user_id=?"
+            cur.execute(sql, ("月灵根", "超灵根", user_id))
+            self.conn.commit()
+        elif int(key) == 4:
+            sql = f"UPDATE user_xiuxian SET root=?,root_type=? WHERE user_id=?"
+            cur.execute(sql, ("言灵灵根", "龙灵根", user_id))
+            self.conn.commit()
+        elif int(key) == 5:
+            sql = f"UPDATE user_xiuxian SET root=?,root_type=? WHERE user_id=?"
+            cur.execute(sql, ("金灵根", "天灵根", user_id))
+            self.conn.commit()            
+            
     def update_ls_all(self, price):
         """所有用户增加灵石"""
         cur = self.conn.cursor()


### PR DESCRIPTION
自己写了个50连（直接输出所有灵根），顺带写了这个GM命令


50连如下
init.py
@command.rrestart.handle()
async def _(bot: Bot, event: GuildMessageEvent):
    """重置灵根信息"""
    try:
        user_id, group_id, mess = await data_check(bot, event)
    except MsgError:
        return

    result2 = sql_message.rramaker(user_id)
    if(result2==1):
        result = ''
        result1 = ''
        for i in range(50):
            name, root_type = XiuxianJsonDate().linggen_get()
            result = name+root_type+'\n'
            result1 += result
    else:
        result1="你的灵石还不够呢，快去赚点灵石吧！"

    await rrestart.send(message=result1)

command.py
rrestart = on_fullmatch("50")

xiuxian2_handle.py
    def rramaker(self, user_id):
        """洗灵根"""
        cur = self.conn.cursor()

        # 查灵石
        sql_s = f"SELECT stone FROM user_xiuxian WHERE user_id=?"
        cur.execute(sql_s, (user_id,))
        result = cur.fetchone()
        if result[0] >= XiuConfig().remakes:
            sql = f"UPDATE user_xiuxian SET stone=stone-? WHERE user_id=?"
            cur.execute(sql, (XiuConfig().remakes, user_id))
            self.conn.commit()

            return 1
        else:
            return 2

config.yaml
remakes: 50000  # 重入仙途50次的消费